### PR TITLE
Updating versions workflow to Java 17

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -103,4 +103,3 @@ jobs:
 
       - name: Verify Specmatic
         run: specmatic --version
-        

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -52,6 +52,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'oracle'
 
       - name: Setup Specmatic Stable
         uses: ./
@@ -83,6 +89,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'oracle'
 
       - name: Setup Specmatic OldStable
         uses: ./

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'oracle'
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'oracle'

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -103,3 +103,4 @@ jobs:
 
       - name: Verify Specmatic
         run: specmatic --version
+        


### PR DESCRIPTION
What: Upgrade versions workflow to Java 17

Why: [Specmatic 1.1.0](https://github.com/znsio/specmatic/releases/tag/1.1.0) onwards works with Java 17

How: Added setups to setup-java instead of relying on the default Java versions in MacOS, Ubuntu and Windows runners since MacOS latest is picking up 12 instead of 13 (which has Java 17). Also Ubuntu and Windows still seem to be on Java 8 or 11. [Runner image reference](https://github.com/actions/runner-images/tree/macOS-12/20231211.1/images).

closes: #259