### PR TITLE
chore(deps-dev): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -45,7 +45,8 @@ module.exports = {
           target: 'ES2022',
           esModuleInterop: true,
           resolveJsonModule: true,
-          allowJs: true
+          allowJs: true,
+          types: ['jest', 'node']
         }
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "nock": "^14.0.12",
         "prettier": "^3.8.3",
         "ts-jest": "^29.4.9",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5958,10 +5958,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10381,9 +10382,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "nock": "^14.0.12",
     "prettier": "^3.8.3",
     "ts-jest": "^29.4.9",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
TS 6.0 stops auto-including every package under node_modules/@types when the caller supplies an inline tsconfig (like ts-jest's transform override) and omits the `types` field. The result is that jest globals (describe, it, expect, beforeAll/Each, jest.spyOn, ...) fail to resolve and the test suite no longer type-checks.

Spell out `types: ['jest', 'node']` in the ts-jest tsconfig override in jest.config.cjs. The root tsconfig.json doesn't need the same change because it excludes **/*.test.ts and src/ never imports jest.