### PR TITLE
chore(release): prepare 1.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file starts at 1.8.0. Earlier releases are described on the
+[releases page](https://github.com/airslate-oss/setup-specmatic/releases).
+
+## [Unreleased]
+
+## [1.8.1] - 2026-08-18
+
+### Fixed
+
+- Version resolution no longer aborts when the upstream Specmatic repository
+  publishes a release tag that carries no attached artifacts. Releases such as
+  `2.52.0` and `2.53.0` ship without a `specmatic.jar`, which made every run
+  fail with `TypeError: Cannot read properties of undefined (reading
+  'browser_download_url')` — including runs that requested an entirely
+  different version. Such releases are now skipped while the version manifest
+  is built, so `stable`, `oldstable`, and explicit version specs again resolve
+  to the newest installable release.
+  ([#817](https://github.com/airslate-oss/setup-specmatic/pull/817))
+
+### Security
+
+- Updated the bundled `undici` to 6.28.0, which addresses CRLF injection
+  through a blob-like body `type` property
+  ([GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5)),
+  downstream response desynchronization in the retry interceptor
+  ([GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524)),
+  and cookie attribute injection via unsanitized `domain` and `setCookie`
+  values
+  ([GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm)).
+  ([#817](https://github.com/airslate-oss/setup-specmatic/pull/817))
+
+## [1.8.0] - 2026-07-20
+
+### Changed
+
+- The action now runs on the Node 20 runtime (`using: node20`) and its sources
+  ship as ES modules. Self-hosted runners and GitHub Enterprise Server
+  installations must provide a runner release that supports `node20`.
+  ([#786](https://github.com/airslate-oss/setup-specmatic/pull/786))
+
+[Unreleased]: https://github.com/airslate-oss/setup-specmatic/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/airslate-oss/setup-specmatic/compare/v1.8.0...v1.8.1
+[1.8.0]: https://github.com/airslate-oss/setup-specmatic/compare/v1.7.4...v1.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-specmatic",
-  "version": "1.7.4",
+  "version": "1.8.1",
   "private": true,
   "description": "Setup specmatic action",
   "homepage": "https://github.com/marketplace/actions/setup-specmatic-environment",


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Introduce a `CHANGELOG.md` (Keep a Changelog format) so future releases have a durable, human-readable history, and bump `package.json` to 1.8.1 to match the changes already released in PR #817.

**Related Issues:** #817

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`CHANGELOG.md` - new file documenting the 1.8.0 and 1.8.1 releases. The 1.8.1 entry records the fix that skips upstream Specmatic release tags with no downloadable assets (which previously crashed `stable`/`oldstable`/explicit version resolution), and the `undici` bump to 6.28.0 addressing three GitHub security advisories (CRLF injection, response desynchronization in the retry interceptor, and cookie attribute injection).

#### Sensitive Areas

- `package.json`: version bump from 1.7.4 to 1.8.1 - no dependency or behavior changes, only the `version` field.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.